### PR TITLE
feat: add electron echo bridge service

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,87 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import path from 'path';
+import { format } from 'url';
+
+/** Channel name used for invoking echo requests from the renderer process. */
+const IPC_CHANNEL_ECHO_INVOKE = 'echo:invoke';
+/** Channel name used when broadcasting processed echo responses back to the renderer. */
+const IPC_CHANNEL_ECHO_BROADCAST = 'echo:broadcast';
+
+/** Holds a reference to the main application window. */
+let mainWindow: BrowserWindow | null = null;
+
+/**
+ * Creates the Electron BrowserWindow and loads the Ionic/Angular application.
+ */
+async function createWindow(): Promise<void> {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      // The preload script wires the IPC bridge using context isolation.
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (process.env.NODE_ENV === 'development') {
+    await mainWindow.loadURL('http://localhost:8100');
+    mainWindow.webContents.openDevTools();
+  } else {
+    await mainWindow.loadURL(
+      format({
+        pathname: path.join(__dirname, '../app/index.html'),
+        protocol: 'file:',
+        slashes: true,
+      })
+    );
+  }
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+/**
+ * Registers the IPC handler that mimics the native Capacitor Echo plugin while running on desktop.
+ */
+function registerIpcHandlers(): void {
+  ipcMain.handle(IPC_CHANNEL_ECHO_INVOKE, async (_event, message: string) => {
+    const response = {
+      original: message,
+      echoed: `${message} (from Electron)` ,
+      processedAt: new Date().toISOString(),
+    };
+
+    // Broadcast the same response to all renderer windows to keep streams in sync.
+    BrowserWindow.getAllWindows().forEach((window) => {
+      window.webContents.send(IPC_CHANNEL_ECHO_BROADCAST, response);
+    });
+
+    return response;
+  });
+}
+
+/**
+ * Ensures the application lifecycle matches the default Electron behavior.
+ */
+function registerLifecycleHooks(): void {
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+      app.quit();
+    }
+  });
+
+  app.on('activate', async () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      await createWindow();
+    }
+  });
+}
+
+app.whenReady().then(async () => {
+  registerIpcHandlers();
+  registerLifecycleHooks();
+  await createWindow();
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,32 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+/** Represents the echo payload exchanged between the renderer and main processes. */
+interface EchoResponse {
+  original: string;
+  echoed: string;
+  processedAt: string;
+}
+
+/** Channel used to invoke echo requests from the renderer process. */
+const IPC_CHANNEL_ECHO_INVOKE = 'echo:invoke';
+/** Channel used by the main process to broadcast responses. */
+const IPC_CHANNEL_ECHO_BROADCAST = 'echo:broadcast';
+
+/**
+ * Exposes a safe subset of the Electron IPC API to the renderer process.
+ */
+contextBridge.exposeInMainWorld('electronAPI', {
+  /**
+   * Invokes the main process echo handler and returns the response payload.
+   */
+  invokeEcho: async (payload: string): Promise<EchoResponse> => {
+    const response = await ipcRenderer.invoke(IPC_CHANNEL_ECHO_INVOKE, payload);
+    return response as EchoResponse;
+  },
+  /**
+   * Registers a listener for echo broadcasts coming from the main process.
+   */
+  onEchoBroadcast: (callback: (payload: EchoResponse) => void) => {
+    ipcRenderer.on(IPC_CHANNEL_ECHO_BROADCAST, (_event, data) => callback(data as EchoResponse));
+  },
+});

--- a/src/app/components/echo-viewer/echo-viewer.component.ts
+++ b/src/app/components/echo-viewer/echo-viewer.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { EchoBridgeService, EchoResponse } from '../../services/echo-bridge.service';
+
+/**
+ * Demonstrates how an Ionic/Angular component can leverage the {@link EchoBridgeService}.
+ */
+@Component({
+  selector: 'app-echo-viewer',
+  template: `
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Electron Echo Demo</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <ion-item>
+          <ion-input
+            placeholder="Enter text to echo"
+            [(ngModel)]="message"
+            (keyup.enter)="sendEcho()"
+          ></ion-input>
+          <ion-button fill="solid" (click)="sendEcho()">Send</ion-button>
+        </ion-item>
+        <ion-item *ngIf="lastResponse">
+          <ion-label>
+            <h2>Echoed</h2>
+            <p>{{ lastResponse.echoed }}</p>
+            <small>Processed at {{ lastResponse.processedAt }}</small>
+          </ion-label>
+        </ion-item>
+      </ion-card-content>
+    </ion-card>
+  `,
+})
+export class EchoViewerComponent implements OnInit, OnDestroy {
+  /** Holds the current input value from the template two-way binding. */
+  public message = '';
+
+  /** Stores the last response for display purposes. */
+  public lastResponse: EchoResponse | null = null;
+
+  /** Maintains the subscription to the reactive response stream. */
+  private responseSubscription?: Subscription;
+
+  constructor(private readonly echoBridge: EchoBridgeService) {}
+
+  /**
+   * Starts listening to the bridge service stream when the component initializes.
+   */
+  public ngOnInit(): void {
+    this.responseSubscription = this.echoBridge.watchResponses().subscribe((response) => {
+      this.lastResponse = response;
+    });
+  }
+
+  /**
+   * Sends the message to the native layer using the bridge service.
+   */
+  public async sendEcho(): Promise<void> {
+    if (!this.message?.trim()) {
+      return;
+    }
+
+    try {
+      await this.echoBridge.echo(this.message.trim());
+    } catch (error) {
+      // In a real application you would surface the error to the user.
+      console.error('Failed to send echo request', error);
+    }
+  }
+
+  /**
+   * Ensures subscriptions are cleaned up when the component is destroyed.
+   */
+  public ngOnDestroy(): void {
+    this.responseSubscription?.unsubscribe();
+  }
+}

--- a/src/app/plugins/echo.plugin.ts
+++ b/src/app/plugins/echo.plugin.ts
@@ -1,0 +1,16 @@
+import { registerPlugin } from '@capacitor/core';
+
+/**
+ * Defines the Capacitor contract for the native Echo plugin.
+ */
+export interface EchoPlugin {
+  /**
+   * Invokes the native echo implementation and returns the echoed string value.
+   */
+  echo(options: { value: string }): Promise<{ value: string }>;
+}
+
+/**
+ * Registers the plugin so it can be imported lazily throughout the Angular application.
+ */
+export const Echo = registerPlugin<EchoPlugin>('Echo');

--- a/src/app/services/echo-bridge.service.ts
+++ b/src/app/services/echo-bridge.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, NgZone } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * Represents the response returned from the native echo logic.
+ */
+export interface EchoResponse {
+  /** The original value that was passed to the echo call. */
+  original: string;
+  /** The transformed echo value returned by the native layer. */
+  echoed: string;
+  /** Timestamp when the message was processed. */
+  processedAt: string;
+}
+
+/**
+ * Extends the global window interface to describe values injected by the Electron preload script.
+ */
+declare global {
+  interface Window {
+    /**
+     * Safe Electron bridge exposed from the preload script.
+     */
+    electronAPI?: {
+      /** Sends a message to the main process and resolves with the echo payload. */
+      invokeEcho: (payload: string) => Promise<EchoResponse>;
+      /** Registers a callback that is triggered when the main process broadcasts an echo event. */
+      onEchoBroadcast: (callback: (payload: EchoResponse) => void) => void;
+    };
+  }
+}
+
+/**
+ * Provides a unified API that works on web, mobile, and the Electron wrapper.
+ * The service automatically chooses between Capacitor plugins and Electron IPC.
+ */
+@Injectable({ providedIn: 'root' })
+export class EchoBridgeService {
+  /** Holds the last response emitted by any echo call for convenient observation inside Angular. */
+  private readonly lastResponseSubject = new BehaviorSubject<EchoResponse | null>(null);
+
+  constructor(private readonly zone: NgZone) {
+    // Ensure Electron listeners are registered only when running inside the Electron shell.
+    if (this.isRunningInsideElectron() && window.electronAPI) {
+      window.electronAPI.onEchoBroadcast((payload) => {
+        // NgZone is leveraged so that updates propagate through Angular's change detection.
+        this.zone.run(() => this.lastResponseSubject.next(payload));
+      });
+    }
+  }
+
+  /**
+   * Exposes a stream of all echo responses received from any platform.
+   */
+  public watchResponses(): Observable<EchoResponse | null> {
+    return this.lastResponseSubject.asObservable();
+  }
+
+  /**
+   * Dispatches an echo request and resolves with the native response.
+   * On Electron, the IPC bridge is used. On mobile/web the Capacitor Echo plugin is used instead.
+   */
+  public async echo(message: string): Promise<EchoResponse> {
+    if (!message) {
+      throw new Error('The message parameter is required when calling echo().');
+    }
+
+    if (this.isRunningInsideElectron() && window.electronAPI?.invokeEcho) {
+      // Delegate to the Electron main process using the bridge defined in the preload script.
+      const electronResponse = await window.electronAPI.invokeEcho(message);
+      this.lastResponseSubject.next(electronResponse);
+      return electronResponse;
+    }
+
+    // Dynamically import the plugin to avoid bundling it for platforms where it is unavailable.
+    const { Echo } = await import('../plugins/echo.plugin');
+    const pluginResult = await Echo.echo({ value: message });
+    const response: EchoResponse = {
+      original: message,
+      echoed: pluginResult.value,
+      processedAt: new Date().toISOString(),
+    };
+    this.lastResponseSubject.next(response);
+    return response;
+  }
+
+  /**
+   * Helper that detects whether the current runtime is the Capacitor Electron platform.
+   */
+  private isRunningInsideElectron(): boolean {
+    return Capacitor.getPlatform() === 'electron';
+  }
+}


### PR DESCRIPTION
## Summary
- add an Angular EchoBridgeService that unifies Capacitor and Electron echo calls
- expose preload and main process bridge code to support IPC communication
- provide an Ionic component example and plugin registration for the echo feature

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd8af727cc8322a2056d42337a0e9c