### PR TITLE
Add Capacitor Electron bridge integration

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,11 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.echoplugin',
+  appName: 'EchoPlugin',
+  webDir: 'www',
+  bundledWebRuntime: false,
+  plugins: {}
+};
+
+export default config;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,76 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { join } from 'path';
+import { CapacitorElectronApp, setupElectronPlugins } from '@capacitor-community/electron';
+
+// Variable que mantendrá la referencia a la ventana principal de la aplicación
+let mainWindow: BrowserWindow | null = null;
+
+// Instancia que configura la aplicación de Capacitor para Electron
+const capacitorApp = new CapacitorElectronApp({
+  mainWindow: {
+    windowOptions: {
+      width: 1024,
+      height: 768,
+      minWidth: 768,
+      minHeight: 600,
+      webPreferences: {
+        preload: join(__dirname, 'preload.js')
+      }
+    }
+  },
+  splashScreen: {
+    useSplashScreen: false
+  }
+});
+
+// Función que crea la ventana principal y carga el contenido de Ionic
+const createWindow = async (): Promise<void> => {
+  await capacitorApp.load();
+  mainWindow = capacitorApp.getMainWindow();
+
+  if (!mainWindow) {
+    throw new Error('No se pudo crear la ventana principal de Electron');
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    mainWindow.webContents.openDevTools({ mode: 'detach' });
+  }
+};
+
+// Registro de manejadores IPC para comunicarse con el proceso de renderizado
+const registrarCanalesIpc = (): void => {
+  // Canal que recibe un mensaje simple y responde con la versión de la app
+  ipcMain.on('obtener-version', () => {
+    if (!mainWindow) {
+      return;
+    }
+
+    const version = app.getVersion();
+    mainWindow.webContents.send('version-info', `Versión de la aplicación: ${version}`);
+  });
+
+  // Canal que usa invocaciones asíncronas para devolver la ruta de descargas del sistema
+  ipcMain.handle('obtener-ruta-descargas', async () => {
+    return app.getPath('downloads');
+  });
+};
+
+// Evento que se dispara cuando Electron ha finalizado la inicialización
+app.whenReady().then(async () => {
+  setupElectronPlugins();
+  registrarCanalesIpc();
+  await createWindow();
+
+  app.on('activate', async () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      await createWindow();
+    }
+  });
+});
+
+// Evento que gestiona el cierre de todas las ventanas en plataformas distintas a macOS
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "echo-plugin-electron",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "ts-node ./main.ts"
+  },
+  "dependencies": {
+    "@capacitor-community/electron": "^5.0.0"
+  },
+  "devDependencies": {
+    "electron": "^26.2.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.0"
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,27 @@
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+
+// Interfaz que describe las funciones expuestas del lado del renderizado
+interface ElectronIpcBridge {
+  send: (canal: string, datos?: unknown) => void;
+  invoke: <T>(canal: string, datos?: unknown) => Promise<T>;
+  on: (canal: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) => void;
+  removeListener: (canal: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) => void;
+}
+
+// Exposición controlada del ipcRenderer al proceso de renderizado utilizando contextBridge
+const electronApi: { ipcRenderer: ElectronIpcBridge } = {
+  ipcRenderer: {
+    // Método para enviar mensajes unidireccionales al proceso principal
+    send: (canal: string, datos?: unknown) => ipcRenderer.send(canal, datos),
+    // Método para invocar canales que retornan una respuesta asincrónica
+    invoke: <T>(canal: string, datos?: unknown) => ipcRenderer.invoke(canal, datos) as Promise<T>,
+    // Método para escuchar eventos provenientes del proceso principal
+    on: (canal: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) =>
+      ipcRenderer.on(canal, listener),
+    // Método para retirar listeners previamente registrados
+    removeListener: (canal: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) =>
+      ipcRenderer.removeListener(canal, listener)
+  }
+};
+
+contextBridge.exposeInMainWorld('ElectronCapacitor', electronApi);

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "types": ["node", "electron"]
+  },
+  "include": ["main.ts", "preload.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "echo-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Aplicación Ionic Angular con envoltorio de Electron usando Capacitor",
+  "scripts": {
+    "start": "ionic serve",
+    "build": "ng build",
+    "postinstall": "cd electron && npm install",
+    "electron:build": "npm run build && cd electron && npm run build",
+    "electron:start": "npm run build && cd electron && npm run start"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.2.0",
+    "@angular/common": "^16.2.0",
+    "@angular/compiler": "^16.2.0",
+    "@angular/core": "^16.2.0",
+    "@angular/forms": "^16.2.0",
+    "@angular/platform-browser": "^16.2.0",
+    "@angular/platform-browser-dynamic": "^16.2.0",
+    "@capacitor/angular": "^5.0.0",
+    "@capacitor/core": "^5.0.0",
+    "@ionic/angular": "^7.0.0",
+    "rxjs": "^7.8.0",
+    "tslib": "^2.6.0",
+    "zone.js": "~0.13.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^16.2.0",
+    "@angular/cli": "^16.2.0",
+    "@angular/compiler-cli": "^16.2.0",
+    "@capacitor/cli": "^5.0.0",
+    "@ionic/angular-toolkit": "^9.0.0",
+    "typescript": "~5.1.0"
+  }
+}

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,0 +1,37 @@
+<!-- Plantilla de ejemplo que muestra botones para interactuar con el proceso principal de Electron -->
+<ion-header>
+  <ion-toolbar color="primary">
+    <ion-title>Integración con Electron</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-card *ngIf="estaEnElectron; else mensajeNavegador">
+    <ion-card-header>
+      <ion-card-title>Conectado a Electron</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-button expand="block" (click)="solicitarVersion()">Solicitar versión</ion-button>
+      <ion-button expand="block" color="secondary" (click)="solicitarRutaDescargas()">
+        Solicitar ruta de descargas
+      </ion-button>
+      <ion-textarea
+        readonly
+        auto-grow="true"
+        label="Respuesta del proceso principal"
+        [value]="respuestaProcesoPrincipal"
+      ></ion-textarea>
+    </ion-card-content>
+  </ion-card>
+
+  <ng-template #mensajeNavegador>
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Modo navegador</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        Esta funcionalidad solo está disponible en la versión de escritorio construida con Electron.
+      </ion-card-content>
+    </ion-card>
+  </ng-template>
+</ion-content>

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,0 +1,71 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ElectronBridgeService, ElectronMessage } from '../../services/electron-bridge.service';
+
+// Componente de ejemplo que muestra cómo consumir el ElectronBridgeService dentro de una página de Ionic
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.page.html'
+})
+export class HomePage implements OnInit, OnDestroy {
+  // Propiedad que almacena el estado de conexión con Electron
+  public estaEnElectron = false;
+
+  // Propiedad que muestra la respuesta recibida desde el proceso principal
+  public respuestaProcesoPrincipal = '';
+
+  // Suscripción para gestionar el canal IPC de actualizaciones en caliente
+  private actualizacionSub?: Subscription;
+
+  // Se inyecta el servicio de puente dentro del constructor del componente
+  constructor(private readonly electronBridge: ElectronBridgeService) {}
+
+  // Método del ciclo de vida de Angular que inicializa la comunicación con Electron
+  public ngOnInit(): void {
+    this.estaEnElectron = this.electronBridge.estaEnElectron();
+
+    if (!this.estaEnElectron) {
+      return;
+    }
+
+    // Se registra un listener para recibir mensajes del proceso principal en el canal 'version-info'
+    this.actualizacionSub = this.electronBridge
+      .escucharCanal<string>('version-info')
+      .subscribe((mensaje) => {
+        this.respuestaProcesoPrincipal = mensaje;
+      });
+  }
+
+  // Método que envía un mensaje al proceso principal solicitando información de versión
+  public solicitarVersion(): void {
+    if (!this.estaEnElectron) {
+      return;
+    }
+
+    const mensaje: ElectronMessage = {
+      canal: 'obtener-version'
+    };
+
+    this.electronBridge.enviarMensaje(mensaje);
+  }
+
+  // Método que invoca un canal con respuesta usando IPC
+  public async solicitarRutaDescargas(): Promise<void> {
+    if (!this.estaEnElectron) {
+      return;
+    }
+
+    const respuesta = await this.electronBridge.invocar<string>({
+      canal: 'obtener-ruta-descargas'
+    });
+
+    if (respuesta) {
+      this.respuestaProcesoPrincipal = respuesta;
+    }
+  }
+
+  // Método del ciclo de vida de Angular que limpia la suscripción cuando el componente se destruye
+  public ngOnDestroy(): void {
+    this.actualizacionSub?.unsubscribe();
+  }
+}

--- a/src/app/services/electron-bridge.service.ts
+++ b/src/app/services/electron-bridge.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, NgZone } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
+import { Observable } from 'rxjs';
+
+// Declaración global para ampliar el objeto Window con la API de Electron expuesta por Capacitor
+export interface ElectronIpcRenderer {
+  send(channel: string, payload?: unknown): void;
+  invoke<T>(channel: string, payload?: unknown): Promise<T>;
+  on(channel: string, listener: (event: unknown, ...args: unknown[]) => void): void;
+  removeListener(channel: string, listener: (event: unknown, ...args: unknown[]) => void): void;
+}
+
+declare global {
+  interface Window {
+    ElectronCapacitor?: {
+      ipcRenderer?: ElectronIpcRenderer;
+    };
+  }
+}
+
+interface ElectronPlugin {
+  ipcRenderer?: ElectronIpcRenderer;
+}
+
+// Interfaz que describe un mensaje básico enviado mediante IPC
+export interface ElectronMessage<T = unknown> {
+  canal: string;
+  datos?: T;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ElectronBridgeService {
+  // Constructor que inyecta NgZone para sincronizar los eventos de Electron con Angular
+  constructor(private readonly ngZone: NgZone) {}
+
+  // Método privado que devuelve la referencia al ipcRenderer expuesto por Capacitor cuando se ejecuta en Electron
+  private obtenerIpcRenderer(): ElectronIpcRenderer | undefined {
+    const esElectron = Capacitor.getPlatform() === 'electron' || Capacitor.isPluginAvailable('Electron');
+    if (!esElectron) {
+      return undefined;
+    }
+
+    const electronPlugin = (Capacitor.Plugins as Record<string, unknown>)?.Electron as ElectronPlugin | undefined;
+
+    if (electronPlugin?.ipcRenderer) {
+      return electronPlugin.ipcRenderer;
+    }
+
+    return window?.ElectronCapacitor?.ipcRenderer;
+  }
+
+  // Método público para saber si la aplicación se está ejecutando dentro de Electron
+  public estaEnElectron(): boolean {
+    return Capacitor.getPlatform() === 'electron' || Boolean(this.obtenerIpcRenderer());
+  }
+
+  // Método que envía un mensaje unidireccional al proceso principal mediante IPC
+  public enviarMensaje<T>(mensaje: ElectronMessage<T>): void {
+    const ipcRenderer = this.obtenerIpcRenderer();
+    if (!ipcRenderer) {
+      console.warn('IPC no disponible: la aplicación no se está ejecutando en Electron.');
+      return;
+    }
+
+    ipcRenderer.send(mensaje.canal, mensaje.datos);
+  }
+
+  // Método que invoca un canal IPC esperando una respuesta del proceso principal
+  public async invocar<TRespuesta = unknown, TEntrada = unknown>(
+    mensaje: ElectronMessage<TEntrada>
+  ): Promise<TRespuesta | undefined> {
+    const ipcRenderer = this.obtenerIpcRenderer();
+    if (!ipcRenderer || typeof ipcRenderer.invoke !== 'function') {
+      console.warn('Invoke IPC no disponible: la aplicación no se está ejecutando en Electron.');
+      return undefined;
+    }
+
+    return ipcRenderer.invoke<TRespuesta>(mensaje.canal, mensaje.datos);
+  }
+
+  // Método que devuelve un observable para escuchar un canal específico desde el proceso principal
+  public escucharCanal<T = unknown>(canal: string): Observable<T> {
+    return new Observable<T>((suscriptor) => {
+      const ipcRenderer = this.obtenerIpcRenderer();
+      if (!ipcRenderer) {
+        suscriptor.error('IPC no disponible: la aplicación no se está ejecutando en Electron.');
+        return;
+      }
+
+      // Función manejadora que reinyecta el flujo dentro del NgZone de Angular
+      const handler = (_event: unknown, payload: T) => {
+        this.ngZone.run(() => suscriptor.next(payload));
+      };
+
+      ipcRenderer.on(canal, handler);
+
+      // Función de limpieza que se ejecuta cuando el observable se completa o se cancela
+      return () => {
+        ipcRenderer.removeListener(canal, handler);
+      };
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an ElectronBridgeService for Ionic Angular to wrap Capacitor Electron IPC usage
- provide an example home page that consumes the bridge service with Spanish inline comments
- configure Electron main and preload processes plus package manifests for desktop builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd907eb22c8322915cd2542d1abc72